### PR TITLE
Definere et maks antall kolonner i bredden

### DIFF
--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -53,12 +53,31 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const localStorageLayout = getFromLocalStorage(history.location.key)
     const extraCols = anyBikeRentalStations ? 1 : 0
 
+    // Limit column count to n if there are not enough space
+    function maxCols(n: number): number {
+        return numberOfStopPlaces + extraCols < n
+            ? numberOfStopPlaces + extraCols
+            : n
+    }
+
     const cols = {
-        lg: numberOfStopPlaces + extraCols,
-        md: numberOfStopPlaces + extraCols,
-        sm: 1,
+        xxlg: maxCols(6),
+        xlg: maxCols(5),
+        lg: maxCols(4),
+        md: maxCols(3),
+        sm: maxCols(2),
         xs: 1,
         xxs: 1,
+    }
+
+    const gridBreakpoints = {
+        xxlg: 2200,
+        xlg: 1600,
+        lg: 1350,
+        md: 996,
+        sm: 768,
+        xs: 480,
+        xxs: 0,
     }
 
     return (
@@ -73,6 +92,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                     key={numberOfStopPlaces}
                     cols={cols}
                     layouts={localStorageLayout}
+                    breakpoints={gridBreakpoints}
                     compactType="horizontal"
                     isResizable={true}
                     onLayoutChange={(layout, layouts) => {

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -53,19 +53,17 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
     const localStorageLayout = getFromLocalStorage(history.location.key)
     const extraCols = anyBikeRentalStations ? 1 : 0
 
-    // Limit column count to n if there are not enough space
-    function maxCols(n: number): number {
-        return numberOfStopPlaces + extraCols < n
-            ? numberOfStopPlaces + extraCols
-            : n
+    // Limit column count if there are not enough space
+    function limitToMax(columns: number): number {
+        return Math.min(numberOfStopPlaces + extraCols, columns)
     }
 
     const cols = {
-        xxlg: maxCols(6),
-        xlg: maxCols(5),
-        lg: maxCols(4),
-        md: maxCols(3),
-        sm: maxCols(2),
+        xxlg: limitToMax(6),
+        xlg: limitToMax(5),
+        lg: limitToMax(4),
+        md: limitToMax(3),
+        sm: limitToMax(2),
         xs: 1,
         xxs: 1,
     }


### PR DESCRIPTION
Fixes #19

Det ble litt hardkodet det her, men usikker på om det finnes bedre måter å sette breakpoints på. Fant ikke noen max/min bredde funksjon for react-grid-layout.
