### PR TITLE
Størrelsejustering av kolonner

### DIFF
--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -58,21 +58,22 @@
 
     .react-grid-item > .react-resizable-handle {
         position: absolute;
-        width: 20px;
+        width: 100%;
         height: 20px;
         bottom: 0;
         right: 0;
-        cursor: se-resize;
+        cursor: s-resize;
     }
 
     .react-grid-item > .react-resizable-handle::after {
         content: "";
         position: absolute;
-        right: 3px;
-        bottom: 3px;
-        width: 5px;
-        height: 5px;
-        border-right: 2px solid rgba(0, 0, 0, 0.4);
-        border-bottom: 2px solid rgba(0, 0, 0, 0.4);
+        left: 0;
+        bottom: 10px;
+        width: 20%;
+        margin: 0 40% 0 40%;
+        height: 4px;
+        border-radius: 2px;
+        background-color: rgba(255, 255, 255, 0.7);
     }
 }

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -63,6 +63,18 @@
         bottom: 0;
         right: 0;
         cursor: s-resize;
+        z-index: 2;
+    }
+
+    .react-grid-item::after {
+        content: "";
+        position: absolute;
+        width: 100%;
+        height: 50px;
+        bottom: 0;
+        right: 0;
+        background: linear-gradient(0deg, rgba(41, 43, 106, 1) 0%, rgba(41, 43, 106, 0.7) 50%, transparent 100%);
+        z-index: 1;
     }
 
     .react-grid-item > .react-resizable-handle::after {

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -61,9 +61,15 @@
         width: 100%;
         height: 20px;
         bottom: 0;
-        right: 0;
         cursor: s-resize;
         z-index: 2;
+        opacity: 0;
+        transition: bottom 0.3s, opacity 0.3s;
+    }
+
+    .react-grid-item:hover > .react-resizable-handle {
+        opacity: 1;
+        bottom: 0.5rem;
     }
 
     .react-grid-item::after {
@@ -72,7 +78,6 @@
         width: 100%;
         height: 50px;
         bottom: 0;
-        right: 0;
         background: linear-gradient(0deg, rgba(41, 43, 106, 1) 0%, rgba(41, 43, 106, 0.7) 50%, transparent 100%);
         z-index: 1;
     }
@@ -80,12 +85,11 @@
     .react-grid-item > .react-resizable-handle::after {
         content: "";
         position: absolute;
-        left: 0;
-        bottom: 10px;
         width: 20%;
-        margin: 0 40% 0 40%;
-        height: 4px;
-        border-radius: 2px;
+        height: 0.25rem;
+        bottom: 0;
+        margin: 0 40%;
+        border-radius: 50vh;
         background-color: rgba(255, 255, 255, 0.7);
     }
 }

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -31,7 +31,7 @@
         width: 100%;
         height: 50px;
         bottom: 0;
-        background: linear-gradient(0deg, rgba(41, 43, 106, 1) 0%, rgba(41, 43, 106, 0.7) 50%, transparent 100%);
+        background: linear-gradient(0deg, rgba($colors-blues-blue10, 1) 0%, rgba($colors-blues-blue10, 0.7) 50%, transparent 100%);
         z-index: 1;
     }
 

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -25,6 +25,16 @@
         z-index: 1;
     }
 
+    .react-grid-item::after {
+        content: "";
+        position: absolute;
+        width: 100%;
+        height: 50px;
+        bottom: 0;
+        background: linear-gradient(0deg, rgba(41, 43, 106, 1) 0%, rgba(41, 43, 106, 0.7) 50%, transparent 100%);
+        z-index: 1;
+    }
+
     .react-grid-item.cssTransforms {
         transition-property: transform;
     }
@@ -70,16 +80,6 @@
     .react-grid-item:hover > .react-resizable-handle {
         opacity: 1;
         bottom: 0.5rem;
-    }
-
-    .react-grid-item::after {
-        content: "";
-        position: absolute;
-        width: 100%;
-        height: 50px;
-        bottom: 0;
-        background: linear-gradient(0deg, rgba(41, 43, 106, 1) 0%, rgba(41, 43, 106, 0.7) 50%, transparent 100%);
-        z-index: 1;
     }
 
     .react-grid-item > .react-resizable-handle::after {


### PR DESCRIPTION
#11 #10

Gjort håndtakene for størrelsejustering av kolonner tydligere, og kun synlige når musepekeren er tilstede. Elemetet animeres inn ved mouseover.

Også lagt til en gradient på bunnen av kolonner.

Før:
![Screenshot 2020-06-24 at 10 08 33](https://user-images.githubusercontent.com/1774972/85520058-b1f47800-b602-11ea-9c0c-4d26712275d3.png)


Etter
![Screenshot 2020-06-24 at 10 07 12](https://user-images.githubusercontent.com/1774972/85519910-81144300-b602-11ea-8aea-bd37d6dcd100.png)
