### PR TITLE
Sortere bysykler basert på avstand

### DIFF
--- a/src/logic/useBikeRentalStations.ts
+++ b/src/logic/useBikeRentalStations.ts
@@ -23,7 +23,7 @@ async function fetchBikeRentalStations(
         .filter((id, index, ids) => ids.indexOf(id) === index)
 
     const allStations = await service.getBikeRentalStations(allStationIds)
-    return allStations.sort((a, b) => a.name.localeCompare(b.name, 'no'))
+    return allStations
 }
 
 export default function useBikeRentalStations(): Array<


### PR DESCRIPTION
Forslag om å sortere bysykler på avstand fra `position`.

Det ser ut som at Entur SDK gir stoppesteder sortert på avstand, så gitt at det er riktig observert, kan man bare fjerne sorteringsfunksjonen i `fetchBikeRentalStations`.

Det kan også tenkes å legge inn en sortering når man henter `nearestPlaces`.

```javascript
nearestPlaces
    .filter(({ type }) => type === 'BikeRentalStation')
    .sort((a, b) => (a.distance > b.distance ? 1 : -1))
    .map(({ id }) => id),
```