### PR TITLE
Display quay name on lines

### DIFF
--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -62,6 +62,7 @@ const DepartureTile = ({
         <Tile title={name} icons={headerIcons} alerts={disruptionMessages}>
             {routes.map((route) => {
                 const subType = groupedDepartures[route][0].subType
+                const quayCode = groupedDepartures[route][0].quay?.publicCode
                 const routeData = groupedDepartures[route].slice(0, 3)
                 const routeType = routeData[0].type
                 const icon = getIcon(routeType, iconColorType, subType)
@@ -71,6 +72,7 @@ const DepartureTile = ({
                         key={route}
                         label={route}
                         subLabels={routeData.map(createTileSubLabel)}
+                        quayCode={quayCode}
                         icon={icon}
                         alerts={getDisruptionMessagesForRoute(
                             groupedDepartures[route],

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -72,7 +72,7 @@ const DepartureTile = ({
                         key={route}
                         label={route}
                         subLabels={routeData.map(createTileSubLabel)}
-                        quayCode={quayCode}
+                        quayCode={quayCode ? `${name} ${quayCode}` : undefined}
                         icon={icon}
                         alerts={getDisruptionMessagesForRoute(
                             groupedDepartures[route],

--- a/src/dashboards/Compact/components/TileRow/index.tsx
+++ b/src/dashboards/Compact/components/TileRow/index.tsx
@@ -11,10 +11,14 @@ export function TileRow({
     icon,
     subLabels,
     alerts,
+    quayCode,
 }: Props): JSX.Element {
     return (
         <div className="tilerow">
-            <div className="tilerow__icon">{icon}</div>
+            <div className="tilerow__icon">
+                {icon}
+                <p className="tilerow__quaycode">{quayCode}</p>
+            </div>
             <div className="tilerow__texts">
                 <Heading3 className="tilerow__label">{label}</Heading3>
                 {alerts && <AlertContainer alerts={alerts} />}
@@ -67,6 +71,7 @@ interface Props {
     subLabels: TileSubLabel[]
     icon: JSX.Element | null
     alerts?: string[]
+    quayCode?: string
 }
 
 interface AlertProps {

--- a/src/dashboards/Compact/components/TileRow/index.tsx
+++ b/src/dashboards/Compact/components/TileRow/index.tsx
@@ -15,12 +15,10 @@ export function TileRow({
 }: Props): JSX.Element {
     return (
         <div className="tilerow">
-            <div className="tilerow__icon">
-                {icon}
-                <p className="tilerow__quaycode">{quayCode}</p>
-            </div>
+            <div className="tilerow__icon">{icon}</div>
             <div className="tilerow__texts">
                 <Heading3 className="tilerow__label">{label}</Heading3>
+                <p className="tilerow__quaycode">{quayCode}</p>
                 {alerts && <AlertContainer alerts={alerts} />}
                 <div className="tilerow__sublabels">
                     {subLabels.map((subLabel, index) => (

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -59,11 +59,11 @@
     }
 
     &__quaycode {
-        margin-top: 0.6rem;
+        margin-top: -0.7rem;
+        margin-bottom: 0.6rem;
         font-size: 0.9rem;
         font-weight: 600;
         opacity: 0.7;
-        text-align: center;
     }
 
     &__sublabels {

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -58,6 +58,14 @@
         }
     }
 
+    &__quaycode {
+        margin-top: 0.6rem;
+        font-size: 0.9rem;
+        font-weight: 600;
+        opacity: 0.7;
+        text-align: center;
+    }
+
     &__sublabels {
         display: grid;
         grid-template-columns: repeat(3, 1fr);

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface LineData {
     situations?: string[]
     hasCancellation?: boolean
     isScheduled?: boolean
+    quay?: Quay
 }
 
 export interface Line {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -227,6 +227,7 @@ export function transformDepartureToLineData(
         ),
         hasCancellation: cancellation,
         isScheduled: !departure.realtime,
+        quay: departure.quay,
     }
 }
 


### PR DESCRIPTION
Closes #53 

Se den grå teksten "P1" og "P2" på bildet:

![Screenshot 2020-08-07 at 14 53 20](https://user-images.githubusercontent.com/1774972/89647358-c0020d80-d8bd-11ea-8a88-ed88940064ae.png)

Vet ikke om der er andre `PubicCode` verdier som er lengre enn noen bokstaver. Dette håndterer lengre navn dårlig.

_Man kan jo også undre hvorfor "Prinsens gate P3" er lagt inn som et eget stopp 🤔_ 